### PR TITLE
feat: add DaemonRpc method rawRequestRpc

### DIFF
--- a/lib/src/daemon_rpc.dart
+++ b/lib/src/daemon_rpc.dart
@@ -201,3 +201,22 @@ class DaemonRpc {
     return GetOutsResponse.fromJson(response);
   }
 }
+
+/// Raw request ready for a JSON-RPC call with authentication if the Authorization value is provided
+///
+/// The raw request without authentication can be used to retrieve the Authenticate response header
+/// needed to generate the Authorization value.
+String rawRequestRpc(Uri rpcUri, String method, Map<String, dynamic> params,
+    [String? authHeaderValue]) {
+  final body = jsonEncode(
+      {"jsonrpc": "2.0", "id": "0", "method": method, "params": params});
+  final authHeader =
+      (authHeaderValue != null) ? 'Authorization: $authHeaderValue\r\n' : '';
+  return 'POST /json_rpc HTTP/1.1\r\n'
+      'Host: ${rpcUri.host}\r\n'
+      '$authHeader'
+      'Content-Type: application/json\r\n'
+      'Content-Length: ${body.length}\r\n'
+      '\r\n'
+      '$body';
+}

--- a/lib/src/daemon_rpc.dart
+++ b/lib/src/daemon_rpc.dart
@@ -200,23 +200,24 @@ class DaemonRpc {
 
     return GetOutsResponse.fromJson(response);
   }
-}
 
-/// Raw request ready for a JSON-RPC call with authentication if the Authorization value is provided
-///
-/// The raw request without authentication can be used to retrieve the Authenticate response header
-/// needed to generate the Authorization value.
-String rawRequestRpc(Uri rpcUri, String method, Map<String, dynamic> params,
-    [String? authHeaderValue]) {
-  final body = jsonEncode(
-      {"jsonrpc": "2.0", "id": "0", "method": method, "params": params});
-  final authHeader =
-      (authHeaderValue != null) ? 'Authorization: $authHeaderValue\r\n' : '';
-  return 'POST /json_rpc HTTP/1.1\r\n'
-      'Host: ${rpcUri.host}\r\n'
-      '$authHeader'
-      'Content-Type: application/json\r\n'
-      'Content-Length: ${body.length}\r\n'
-      '\r\n'
-      '$body';
+  /// Raw request ready for a JSON-RPC call with authentication if the Authorization value is provided
+  ///
+  /// The raw request without authentication can be used to retrieve the Authenticate response header
+  /// needed to generate the Authorization value.
+  static String rawRequestRpc(
+      Uri rpcUri, String method, Map<String, dynamic> params,
+      [String? authHeaderValue]) {
+    final body = jsonEncode(
+        {"jsonrpc": "2.0", "id": "0", "method": method, "params": params});
+    final authHeader =
+        (authHeaderValue != null) ? 'Authorization: $authHeaderValue\r\n' : '';
+    return 'POST /json_rpc HTTP/1.1\r\n'
+        'Host: ${rpcUri.host}\r\n'
+        '$authHeader'
+        'Content-Type: application/json\r\n'
+        'Content-Length: ${body.length}\r\n'
+        '\r\n'
+        '$body';
+  }
 }

--- a/test/daemon_rpc_test.dart
+++ b/test/daemon_rpc_test.dart
@@ -14,7 +14,8 @@ void main() {
   });
   test('Raw request without authentication', () {
     expect(
-        rawRequestRpc(Uri.parse('http://localhost:18081'), 'get_info', {}),
+        DaemonRpc.rawRequestRpc(
+            Uri.parse('http://localhost:18081'), 'get_info', {}),
         'POST /json_rpc HTTP/1.1\r\n'
         'Host: localhost\r\n'
         'Content-Type: application/json\r\n'
@@ -26,8 +27,8 @@ void main() {
     final authorizationHeaderValue =
         'Digest username="user", realm="monero-rpc", nonce="test", uri="http://localhost:18081", qop=auth, nc=00000001, cnonce="test", response="test"';
     expect(
-        rawRequestRpc(Uri.parse('http://localhost:18081'), 'get_info', {},
-            authorizationHeaderValue),
+        DaemonRpc.rawRequestRpc(Uri.parse('http://localhost:18081'), 'get_info',
+            {}, authorizationHeaderValue),
         'POST /json_rpc HTTP/1.1\r\n'
         'Host: localhost\r\n'
         'Authorization: $authorizationHeaderValue\r\n'

--- a/test/daemon_rpc_test.dart
+++ b/test/daemon_rpc_test.dart
@@ -12,4 +12,28 @@ void main() {
     final result = await walletRpc.call('get_info', {});
     expect(result, isA<Map<String, dynamic>>());
   });
+  test('Raw request without authentication', () {
+    expect(
+        rawRequestRpc(Uri.parse('http://localhost:18081'), 'get_info', {}),
+        'POST /json_rpc HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Content-Type: application/json\r\n'
+        'Content-Length: 58\r\n'
+        '\r\n'
+        '{"jsonrpc":"2.0","id":"0","method":"get_info","params":{}}');
+  });
+  test('Raw request with authentication', () {
+    final authorizationHeaderValue =
+        'Digest username="user", realm="monero-rpc", nonce="test", uri="http://localhost:18081", qop=auth, nc=00000001, cnonce="test", response="test"';
+    expect(
+        rawRequestRpc(Uri.parse('http://localhost:18081'), 'get_info', {},
+            authorizationHeaderValue),
+        'POST /json_rpc HTTP/1.1\r\n'
+        'Host: localhost\r\n'
+        'Authorization: $authorizationHeaderValue\r\n'
+        'Content-Type: application/json\r\n'
+        'Content-Length: 58\r\n'
+        '\r\n'
+        '{"jsonrpc":"2.0","id":"0","method":"get_info","params":{}}');
+  });
 }


### PR DESCRIPTION
This new method allows to get the raw request needed to perform a JSON-RPC call with/without authentication.

Handy to use directly with a sock.